### PR TITLE
Modifying sqs scheduler tobe enabled by default

### DIFF
--- a/cinq_scheduler_sqs/__init__.py
+++ b/cinq_scheduler_sqs/__init__.py
@@ -22,7 +22,7 @@ class SQSScheduler(BaseScheduler):
     ns = NS_SCHEDULER_SQS
     enabled = dbconfig.get('enabled', ns, True)
     options = (
-        ConfigOption('enabled', False, 'bool', 'Enable SQS based scheduler'),
+        ConfigOption('enabled', True, 'bool', 'Enable SQS based scheduler'),
         ConfigOption('queue_region', 'us-west-2', 'string', 'Region of the SQS Queues'),
         ConfigOption('job_queue_url', '', 'string', 'URL of the SQS Queue for pending jobs'),
         ConfigOption('status_queue_url', '', 'string', 'URL of the SQS Queue for worker reports'),


### PR DESCRIPTION
Modifying sqs scheduler tobe enabled by default.

Based on recent upgrade testing, it's better to enable the SQS scheduler by default to assist with troubleshooting and having the collectors run immediately.