### PR TITLE
Use get_local_aws_session instead of manual boto3 sessions

### DIFF
--- a/cinq_scheduler_sqs/__init__.py
+++ b/cinq_scheduler_sqs/__init__.py
@@ -2,11 +2,10 @@ import json
 from datetime import datetime, timedelta
 from uuid import uuid4
 
-import boto3.session
 from apscheduler.executors.pool import ProcessPoolExecutor
 from apscheduler.schedulers.blocking import BlockingScheduler as APScheduler
 from botocore.exceptions import ClientError
-from cloud_inquisitor import app_config, AWS_REGIONS
+from cloud_inquisitor import app_config, get_local_aws_session, AWS_REGIONS
 from cloud_inquisitor.config import dbconfig, ConfigOption
 from cloud_inquisitor.constants import NS_SCHEDULER_SQS, SchedulerStatus, AccountTypes
 from cloud_inquisitor.database import db
@@ -45,13 +44,7 @@ class SQSScheduler(BaseScheduler):
             }
         )
 
-        access_key = app_config.aws_api.access_key
-        secret_key = app_config.aws_api.secret_key
-        if access_key and secret_key:
-            session = boto3.session.Session(access_key, secret_key)
-        else:
-            session = boto3.session.Session()
-
+        session = get_local_aws_session()
         sqs = session.resource('sqs', self.dbconfig.get('queue_region', self.ns))
 
         self.job_queue = sqs.Queue(self.dbconfig.get('job_queue_url', self.ns))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'cloud-inquisitor~=1.1.0',
+        'cloud-inquisitor~=1.1.1',
         'APScheduler~=3.3',
         'boto3~=1.4',
     ],


### PR DESCRIPTION
Support new get_local_aws_session instead of manually getting a boto3 session as per https://github.com/RiotGames/cloud-inquisitor/pull/123